### PR TITLE
add inspector code from textusgamer

### DIFF
--- a/Assets/AnyRPG/Engine/Core/System/Scripts/Quest/CollectObjective.cs
+++ b/Assets/AnyRPG/Engine/Core/System/Scripts/Quest/CollectObjective.cs
@@ -9,6 +9,7 @@ namespace AnyRPG {
     [System.Serializable]
     public class CollectObjective : QuestObjective {
 
+        public string collectItemName;
         public override Type ObjectiveType {
             get {
                 return typeof(CollectObjective);

--- a/Assets/AnyRPG/Engine/Core/System/Scripts/Quest/CollectObjective.cs
+++ b/Assets/AnyRPG/Engine/Core/System/Scripts/Quest/CollectObjective.cs
@@ -9,7 +9,6 @@ namespace AnyRPG {
     [System.Serializable]
     public class CollectObjective : QuestObjective {
 
-        public string collectItemName;
         public override Type ObjectiveType {
             get {
                 return typeof(CollectObjective);

--- a/Assets/AnyRPG/Engine/Core/System/Scripts/Quest/Quest.cs
+++ b/Assets/AnyRPG/Engine/Core/System/Scripts/Quest/Quest.cs
@@ -124,6 +124,10 @@ namespace AnyRPG {
 
         [Header("Objectives")]
 
+        [SerializeReference]
+        [SerializeReferenceButton]
+        private List<QuestObjective> baseObjectives = new List<QuestObjective>();
+
         [SerializeField]
         private CollectObjective[] collectObjectives;
 

--- a/Assets/AnyRPG/Engine/Core/System/Scripts/Quest/QuestObjective.cs
+++ b/Assets/AnyRPG/Engine/Core/System/Scripts/Quest/QuestObjective.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 
 namespace AnyRPG {
     [System.Serializable]
-    public abstract class QuestObjective {
+    public class QuestObjective {
         [SerializeField]
         private int amount;
 

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus.meta
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3c8c13f4c0feb7dccb5308c6885e6edc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI.meta
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f549199d6eac96943ae073e003f12aa3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/Core.meta
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/Core.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1388bc43afa1f4e41ba1032dcee62b04
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/Core/ManagedReferenceUtility.cs
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/Core/ManagedReferenceUtility.cs
@@ -1,0 +1,101 @@
+﻿#if UNITY_EDITOR
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+public static class ManagedReferenceUtility
+{
+    /// Creates instance of passed type and assigns it to managed reference
+    public static object AssignNewInstanceOfTypeToManagedReference(this SerializedProperty serializedProperty, Type type)
+    {
+        var instance = Activator.CreateInstance(type);
+        
+        serializedProperty.serializedObject.Update(); 
+        serializedProperty.managedReferenceValue = instance;
+        serializedProperty.serializedObject.ApplyModifiedProperties(); 
+        
+        return instance;
+    }
+
+    /// Sets managed reference to null
+    public static void SetManagedReferenceToNull(this SerializedProperty serializedProperty)
+    {
+        serializedProperty.serializedObject.Update();
+        serializedProperty.managedReferenceValue = null;
+        serializedProperty.serializedObject.ApplyModifiedProperties(); 
+    }
+
+    /// Collects appropriate types based on managed reference field type and filters. Filters all derive
+    public static IEnumerable<Type> GetAppropriateTypesForAssigningToManagedReference(this SerializedProperty property, List<Func<Type, bool>> filters = null)
+    {
+        var fieldType = property.GetManagedReferenceFieldType();
+        return GetAppropriateTypesForAssigningToManagedReference(fieldType, filters);
+    }
+
+    /// Filters derived types of field typ parameter and finds ones whose are compatible with managed reference and filters.
+    public static IEnumerable<Type> GetAppropriateTypesForAssigningToManagedReference(Type fieldType, List<Func<Type, bool>> filters = null)
+    {
+        var appropriateTypes = new List<Type>();
+
+        // Get and filter all appropriate types
+        var derivedTypes = TypeCache.GetTypesDerivedFrom(fieldType);
+        foreach (var type in derivedTypes)
+        {
+            // Skips unity engine Objects (because they are not serialized by SerializeReference)
+            if (type.IsSubclassOf(typeof(Object)))
+                continue;
+            // Skip abstract classes because they should not be instantiated
+            if (type.IsAbstract)
+                continue;
+			// Skip generic classes because they can not be instantiated
+            if (type.ContainsGenericParameters)
+                continue;
+            // Skip types that has no public empty constructors (activator can not create them)    
+            if (type.IsClass && type.GetConstructor(Type.EmptyTypes) == null) // Structs still can be created (strangely)
+                continue;
+            // Filter types by provided filters if there is ones
+            if (filters != null && filters.All(f => f == null || f.Invoke(type)) == false) 
+                continue;
+
+            appropriateTypes.Add(type);
+        }
+
+        return appropriateTypes;
+    }
+    
+    /// Gets real type of managed reference
+    public static Type GetManagedReferenceFieldType(this SerializedProperty property)
+    {
+        var realPropertyType = GetRealTypeFromTypename(property.managedReferenceFieldTypename);
+        if (realPropertyType != null) 
+            return realPropertyType;
+        
+        Debug.LogError($"Can not get field type of managed reference : {property.managedReferenceFieldTypename}");
+        return null;
+    }
+    
+    /// Gets real type of managed reference's field typeName
+    public static Type GetRealTypeFromTypename(string stringType)
+    {
+        var names = GetSplitNamesFromTypename(stringType);
+        var realType = Type.GetType($"{names.ClassName}, {names.AssemblyName}");
+        return realType;
+    }
+    
+    /// Get assembly and class names from typeName
+    public static (string AssemblyName, string ClassName) GetSplitNamesFromTypename(string typename)
+    {
+        if (string.IsNullOrEmpty(typename))  
+            return ("","");
+        
+        var typeSplitString = typename.Split(char.Parse(" "));
+        var typeClassName = typeSplitString[1];
+        var typeAssemblyName = typeSplitString[0];
+        return (typeAssemblyName,  typeClassName); 
+    }
+}
+#endif

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/Core/ManagedReferenceUtility.cs.meta
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/Core/ManagedReferenceUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 07d7d3b6c96d5a04093953c060518522
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/Core/SerializeReferenceGenericSelectionMenu.cs
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/Core/SerializeReferenceGenericSelectionMenu.cs
@@ -1,0 +1,82 @@
+﻿#if UNITY_EDITOR
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+ 
+public static class SerializeReferenceGenericSelectionMenu
+{
+    /// Purpose.
+    /// This is generic selection menu (will appear at position).
+    /// Filtering. 
+    /// You can add substring filter here to filter by search string.
+    /// As well ass type or interface restrictions.
+    /// As well as any custom restriction that is based on input type.
+    /// And it will be performed on each Appropriate type found by TypeCache.
+    public static void ShowContextMenuForManagedReference(this SerializedProperty property, Rect position, IEnumerable<Func<Type,bool>> filters = null)
+    { 
+        var context = new GenericMenu();
+        FillContextMenu(filters, context, property);
+        context.DropDown(position);
+    }
+
+    /// Purpose.
+    /// This is generic selection menu (will appear at click position).
+    /// Filtering. 
+    /// You can add substring filter here to filter by search string.
+    /// As well ass type or interface restrictions.
+    /// As well as any custom restriction that is based on input type.
+    /// And it will be performed on each Appropriate type found by TypeCache.
+    public static void ShowContextMenuForManagedReference(this SerializedProperty property, IEnumerable<Func<Type, bool>> filters = null)
+    {
+        var context = new GenericMenu();
+        FillContextMenu(filters, context, property);
+        context.ShowAsContext();
+    }
+    
+    private static void FillContextMenu(IEnumerable<Func<Type, bool>> enumerableFilters, GenericMenu contextMenu, SerializedProperty property)
+    {
+        var filters = enumerableFilters.ToList();// Prevents possible multiple enumerations
+        
+        // Adds "Make Null" menu command
+        contextMenu.AddItem(new GUIContent("Null"), false, property.SetManagedReferenceToNull);
+         
+        // Collects appropriate types
+        var appropriateTypes = property.GetAppropriateTypesForAssigningToManagedReference(filters);
+        
+        // Adds appropriate types to menu
+        foreach (var appropriateType in appropriateTypes)
+            AddItemToContextMenu(appropriateType, contextMenu, property); 
+    }
+    
+    private static void AddItemToContextMenu(Type type, GenericMenu genericMenuContext, SerializedProperty property)
+    {
+        var assemblyName =  type.Assembly.ToString().Split('(', ',')[0];
+        var entryName = type + "  ( " + assemblyName + " )";
+        genericMenuContext.AddItem(new GUIContent(entryName), false, AssignNewInstanceCommand, new GenericMenuParameterForAssignInstanceCommand(type, property));
+    }
+    
+    private static void AssignNewInstanceCommand(object objectGenericMenuParameter )
+    {
+        var parameter = (GenericMenuParameterForAssignInstanceCommand) objectGenericMenuParameter;
+        var type = parameter.Type;
+        var property = parameter.Property;
+        property.AssignNewInstanceOfTypeToManagedReference(type);
+    }
+
+    private readonly struct GenericMenuParameterForAssignInstanceCommand
+    {
+        public GenericMenuParameterForAssignInstanceCommand(Type type, SerializedProperty property)
+        {
+            Type = type;
+            Property = property;
+        }
+        
+        public readonly SerializedProperty Property;
+        public readonly Type Type;
+    }
+} 
+
+#endif

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/Core/SerializeReferenceGenericSelectionMenu.cs.meta
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/Core/SerializeReferenceGenericSelectionMenu.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d7796948b498be241ba10c88bcf3d5fe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/Core/SerializeReferenceTypeRestrictionFilters.cs
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/Core/SerializeReferenceTypeRestrictionFilters.cs
@@ -1,0 +1,14 @@
+﻿    using System;
+using System.Linq;
+
+public static class SerializeReferenceTypeRestrictionFilters
+{
+    public static Func<Type, bool> TypeIsNotSubclassOrEqualOrHasInterface(Type[] types) => type =>
+        TypeIsSubclassOrEqualOrHasInterface(types).Invoke(type) == false;
+
+    public static Func<Type, bool> TypeIsSubclassOrEqualOrHasInterface(Type[] types) => type =>
+        types.Any(e => e.IsInterface ? TypeHasInterface(type, e) : TypeIsSubclassOrEqual(type, e));
+
+    public static bool TypeIsSubclassOrEqual(Type type, Type comparator) =>  type.IsSubclassOf(comparator) || type == comparator;
+    public static bool TypeHasInterface(this Type type, Type comparator) =>  type.GetInterface(comparator.ToString()) != null;
+}

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/Core/SerializeReferenceTypeRestrictionFilters.cs.meta
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/Core/SerializeReferenceTypeRestrictionFilters.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b71802ffed0a18d43901672fcbf668c9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes.meta
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c962b02723999754ba9b137d407b5ec0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceButtonAttribute.meta
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceButtonAttribute.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 827f3a2847b39a94eb6fcbdb0d73d6ca
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceButtonAttribute/SerializeReferenceButtonAttribute.cs
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceButtonAttribute/SerializeReferenceButtonAttribute.cs
@@ -1,0 +1,8 @@
+﻿using System;
+using UnityEngine;
+
+[AttributeUsage(AttributeTargets.Field)]
+public class SerializeReferenceButtonAttribute : PropertyAttribute
+{
+    
+}

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceButtonAttribute/SerializeReferenceButtonAttribute.cs.meta
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceButtonAttribute/SerializeReferenceButtonAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c64e0f68b41b48939c9b98cc29a19b20
+timeCreated: 1579584059

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceButtonAttribute/SerializeReferenceButtonAttributeDrawer.cs
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceButtonAttribute/SerializeReferenceButtonAttributeDrawer.cs
@@ -1,0 +1,31 @@
+﻿#if UNITY_EDITOR
+
+using UnityEditor; 
+using UnityEngine;
+
+[CustomPropertyDrawer(typeof(SerializeReferenceButtonAttribute))]
+public class SerializeReferenceButtonAttributeDrawer : PropertyDrawer
+{
+    public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+    {
+        return EditorGUI.GetPropertyHeight(property, true);
+    }
+ 
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+
+        
+        EditorGUI.BeginProperty(position, label, property); 
+        
+        var labelPosition = new Rect(position.x, position.y, position.width, EditorGUIUtility.singleLineHeight);
+        EditorGUI.LabelField(labelPosition, label);    
+         
+        var typeRestrictions = SerializedReferenceUIDefaultTypeRestrictions.GetAllBuiltInTypeRestrictions(fieldInfo);
+        property.DrawSelectionButtonForManagedReference(position, typeRestrictions);
+        
+        EditorGUI.PropertyField(position, property, GUIContent.none, true);
+        
+        EditorGUI.EndProperty(); 
+    } 
+}
+#endif

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceButtonAttribute/SerializeReferenceButtonAttributeDrawer.cs.meta
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceButtonAttribute/SerializeReferenceButtonAttributeDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5a07638044724309b6088c28a11a15af
+timeCreated: 1579584059

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceMenuAttribute.meta
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceMenuAttribute.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ff8136ca43f822642adfa6388b137133
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceMenuAttribute/SerializeReferenceMenuAttribute.cs
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceMenuAttribute/SerializeReferenceMenuAttribute.cs
@@ -1,0 +1,8 @@
+﻿using System;
+using UnityEngine;
+
+[AttributeUsage(AttributeTargets.Field)]
+public class SerializeReferenceMenuAttribute : PropertyAttribute
+{
+    
+}

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceMenuAttribute/SerializeReferenceMenuAttribute.cs.meta
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceMenuAttribute/SerializeReferenceMenuAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4f1c372fa681cf146973df30a0d969fd
+timeCreated: 1579584059

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceMenuAttribute/SerializeReferenceMenuAttributeDrawer.cs
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceMenuAttribute/SerializeReferenceMenuAttributeDrawer.cs
@@ -1,0 +1,26 @@
+﻿#if UNITY_EDITOR
+
+using UnityEditor;
+using UnityEngine;
+
+[CustomPropertyDrawer(typeof(SerializeReferenceMenuAttribute))]
+public class SerializeReferenceMenuAttributeDrawer : PropertyDrawer
+{
+    public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+    {
+        return EditorGUI.GetPropertyHeight(property, true);
+    }
+
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        EditorGUI.BeginProperty(position, label, property);
+        
+        var typeRestrictions = SerializedReferenceUIDefaultTypeRestrictions.GetAllBuiltInTypeRestrictions(fieldInfo);
+        property.ShowContextMenuForManagedReferenceOnMouseMiddleButton(position, typeRestrictions);
+        
+        EditorGUI.PropertyField(position, property, true);
+        EditorGUI.EndProperty();
+    }
+}
+#endif
+

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceMenuAttribute/SerializeReferenceMenuAttributeDrawer.cs.meta
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceMenuAttribute/SerializeReferenceMenuAttributeDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: eaa31b1c39ee9424abe12fa0034d9d1b
+timeCreated: 1579584059

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceUIRestrictionExcludeTypes.meta
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceUIRestrictionExcludeTypes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3fbe55d72b5fd59459fdb52e0f301ea1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceUIRestrictionExcludeTypes/SerializeReferenceUIRestrictionExcludeTypes.cs
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceUIRestrictionExcludeTypes/SerializeReferenceUIRestrictionExcludeTypes.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using UnityEngine;
+
+/// None of this types or interface types are valid.
+[AttributeUsage(AttributeTargets.Field)]
+public class SerializeReferenceUIRestrictionExcludeTypes : PropertyAttribute
+{
+    public readonly Type[] Types;
+    public SerializeReferenceUIRestrictionExcludeTypes(params Type[] types) => Types = types;
+} 

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceUIRestrictionExcludeTypes/SerializeReferenceUIRestrictionExcludeTypes.cs.meta
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceUIRestrictionExcludeTypes/SerializeReferenceUIRestrictionExcludeTypes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ff5f6060287437048acba59e670cd000
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceUIRestrictionIncludeTypes.meta
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceUIRestrictionIncludeTypes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c0c77910f7962a14cb85132596cb8d24
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceUIRestrictionIncludeTypes/SerializeReferenceUIRestrictionIncludeTypes.cs
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceUIRestrictionIncludeTypes/SerializeReferenceUIRestrictionIncludeTypes.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using UnityEngine;
+
+/// Any of this types or interface types are valid. And only this types can be presented.
+[AttributeUsage(AttributeTargets.Field)]
+public class SerializeReferenceUIRestrictionIncludeTypes : PropertyAttribute
+{
+    public readonly Type[] Types;
+    public SerializeReferenceUIRestrictionIncludeTypes(params Type[] types) => Types = types;
+}

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceUIRestrictionIncludeTypes/SerializeReferenceUIRestrictionIncludeTypes.cs.meta
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializeReferenceUIRestrictionIncludeTypes/SerializeReferenceUIRestrictionIncludeTypes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6d10fb8315984ef458e4129191b17931
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializedReferenceUIDefaultTypeRestrictions.cs
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializedReferenceUIDefaultTypeRestrictions.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+public static class SerializedReferenceUIDefaultTypeRestrictions
+{
+    public static IEnumerable<Func<Type, bool>> GetAllBuiltInTypeRestrictions(FieldInfo fieldInfo)
+    {
+        var result = new List<Func<Type, bool>>();
+        
+        var attributeObjects = fieldInfo.GetCustomAttributes(false);
+        foreach (var attributeObject in attributeObjects)
+        {
+            switch (attributeObject)
+            { 
+                case SerializeReferenceUIRestrictionIncludeTypes includeTypes:
+                    result.Add(SerializeReferenceTypeRestrictionFilters.TypeIsSubclassOrEqualOrHasInterface(includeTypes.Types)); 
+                    continue;
+                case SerializeReferenceUIRestrictionExcludeTypes excludeTypes:
+                    result.Add(SerializeReferenceTypeRestrictionFilters.TypeIsNotSubclassOrEqualOrHasInterface(excludeTypes.Types)); 
+                    continue;
+            } 
+        }
+        return result; 
+    }
+} 

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializedReferenceUIDefaultTypeRestrictions.cs.meta
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultAttributes/SerializedReferenceUIDefaultTypeRestrictions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 95f44dc0cd315cf4988029eb8618aa02
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultUI.meta
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultUI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4a5d0da55302d3d418d5afe408a9a916
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultUI/SerializeReferenceInspectorButton.cs
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultUI/SerializeReferenceInspectorButton.cs
@@ -1,0 +1,45 @@
+﻿#if UNITY_EDITOR
+
+using System;
+using System.Collections.Generic; 
+using UnityEditor;
+using UnityEngine;
+
+public static class SerializeReferenceInspectorButton
+{
+    public static readonly Color SerializedReferenceMenuBackgroundColor = new Color(0.1f, 0.55f, 0.9f, 1f);
+
+    /// Must be drawn before DefaultProperty in order to receive input
+    public static void DrawSelectionButtonForManagedReference(this SerializedProperty property,  Rect position, IEnumerable<Func<Type, bool>> filters = null) =>  
+        property.DrawSelectionButtonForManagedReference(position, SerializedReferenceMenuBackgroundColor, filters);
+    
+    /// Must be drawn before DefaultProperty in order to receive input
+    public static void DrawSelectionButtonForManagedReference(this SerializedProperty property, 
+        Rect position, Color color, IEnumerable<Func<Type, bool>> filters = null)  
+    { 
+  
+        var backgroundColor = color;   
+            
+        var buttonPosition = position;
+        buttonPosition.x += EditorGUIUtility.labelWidth + 1 * EditorGUIUtility.standardVerticalSpacing;
+        buttonPosition.width = position.width - EditorGUIUtility.labelWidth - 1 * EditorGUIUtility.standardVerticalSpacing;
+        buttonPosition.height = EditorGUIUtility.singleLineHeight;
+
+        var storedIndent = EditorGUI.indentLevel;
+        EditorGUI.indentLevel = 0;
+        var storedColor = GUI.backgroundColor;
+        GUI.backgroundColor = backgroundColor; 
+         
+        
+        var names = ManagedReferenceUtility.GetSplitNamesFromTypename(property.managedReferenceFullTypename);
+        var className = string.IsNullOrEmpty(names.ClassName) ? "Null (Assign)" : names.ClassName;
+        var assemblyName = names.AssemblyName;
+        if (GUI.Button(buttonPosition, new GUIContent(className, className + "  ( "+ assemblyName +" )" )))
+            property.ShowContextMenuForManagedReference(buttonPosition, filters);
+        
+        GUI.backgroundColor = storedColor;
+        EditorGUI.indentLevel = storedIndent;
+    }
+}
+
+#endif

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultUI/SerializeReferenceInspectorButton.cs.meta
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultUI/SerializeReferenceInspectorButton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 50b013bc3b4409b438f8781dee4dbbf1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultUI/SerializeReferenceInspectorMiddleMouseMenu.cs
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultUI/SerializeReferenceInspectorMiddleMouseMenu.cs
@@ -1,0 +1,21 @@
+﻿#if UNITY_EDITOR
+
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+public static class SerializeReferenceInspectorMiddleMouseMenu
+{
+    public static void ShowContextMenuForManagedReferenceOnMouseMiddleButton(this SerializedProperty property,
+        Rect position, IEnumerable<Func<Type, bool>> filters = null)
+    {
+        var e = Event.current;
+        if (e.type != EventType.MouseDown || !position.Contains(e.mousePosition) || e.button != 2) 
+            return;
+        
+        property.ShowContextMenuForManagedReference(filters);
+    } 
+}
+
+#endif

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultUI/SerializeReferenceInspectorMiddleMouseMenu.cs.meta
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/DefaultUI/SerializeReferenceInspectorMiddleMouseMenu.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ba51bcbc90077924abfcf504152b4a51
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/LICENSE.txt
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 TextusGames
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/LICENSE.txt.meta
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/LICENSE.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 97e871ef367e1604391241355b1b3962
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/Textus.SerializeReferenceUI.asmdef
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/Textus.SerializeReferenceUI.asmdef
@@ -1,0 +1,3 @@
+﻿{
+	"name": "Textus.SerializeReferenceUI"
+}

--- a/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/Textus.SerializeReferenceUI.asmdef.meta
+++ b/Assets/AnyRPG/Engine/Core/System/ThirdPartyContent/Textus/SerializeReferenceUI/Textus.SerializeReferenceUI.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 73106583b323919458c1e05166706ce3
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
There is already code for a proper inspector handling of generic lists serialized with the standard Unity SerializeReference attribute.
The author expressed his wish that Unity would adapt his code and according to a developer they are considering exactly that and only some organizational issues hold them back for the time being.
The code is MIT licensed.

I tested it with some changes in Quest.cs and it works fine.