### PR TITLE
work-around for the general case of the resource selector

### DIFF
--- a/Assets/AnyRPG/Engine/Core/System/Scripts/Editor/ResourceSelector/DummyResourceManager.cs
+++ b/Assets/AnyRPG/Engine/Core/System/Scripts/Editor/ResourceSelector/DummyResourceManager.cs
@@ -5,8 +5,48 @@ namespace AnyRPG {
     public class DummyResourceManager : FactoryResource
     {
         public string resourceClassName;
+        List<ResourceProfile> allResources = new List<ResourceProfile>();
 
         System.Type type;
+
+        List<string> validFolders = new List<string> {
+            typeof(AbilityEffect).Name,
+            typeof(AnimationProfile).Name,
+            typeof(ArmorClass).Name,
+            typeof(AudioProfile).Name,
+            typeof(BaseAbility).Name,
+            typeof(BehaviorProfile).Name,
+            typeof(CharacterClass).Name,
+            typeof(CharacterRace).Name,
+            typeof(ClassSpecialization).Name,
+            typeof(CombatStrategy).Name,
+            typeof(Currency).Name,
+            typeof(CurrencyGroup).Name,
+            typeof(Cutscene).Name,
+            typeof(Dialog).Name,
+            typeof(EnvironmentStateProfile).Name,
+            typeof(EquipmentSet).Name,
+            typeof(Faction).Name,
+            typeof(InteractableOptionConfig).Name,
+            typeof(Item).Name,
+            typeof(ItemQuality).Name,
+            typeof(LootTable).Name,
+            typeof(MaterialProfile).Name,
+            typeof(PatrolProfile).Name,
+            typeof(PowerResource).Name,
+            typeof(PrefabProfile).Name,
+            typeof(Quest).Name,
+            typeof(Recipe).Name,
+            typeof(SceneNode).Name,
+            typeof(Skill).Name,
+            typeof(StatusEffectType).Name,
+            typeof(UMARecipeProfile).Name,
+            typeof(UnitProfile).Name,
+            typeof(UnitToughness).Name,
+            typeof(UnitType).Name,
+            typeof(VendorCollection).Name,
+            typeof(WeaponSkill).Name
+        };
 
         public DummyResourceManager(System.Type resourceType) {
             this.type = resourceType;
@@ -16,7 +56,8 @@ namespace AnyRPG {
         public override void LoadResourceList() {
             List<string> mappedClassNames = new List<string>();
             if (resourceClassName == "ResourceProfile") {
-                GenericLoadList<ResourceProfile>("");
+                foreach (string folder in validFolders)
+                    GenericLoadList<ResourceProfile>(folder);
             } else {
                 if (resourceClassName == "Equipment") {
                     mappedClassNames.Add("Item/Accessory");
@@ -29,7 +70,12 @@ namespace AnyRPG {
                     GenericLoadList<ResourceProfile>(className);
                 }
             }
-            base.LoadResourceList();
+            //base.LoadResourceList();
+            // other than the in-game resource managers we only need a list of all the resources
+            allResources = new List<ResourceProfile>();
+            foreach (ResourceProfile[] subList in masterList) {
+                allResources.AddRange(subList);
+            }
         }
 
         void GenericLoadList<T>(string folder) where T: ResourceProfile {
@@ -43,12 +89,13 @@ namespace AnyRPG {
         }
 
         public List<ResourceProfile> GetResourceList() {
-            List<ResourceProfile> returnList = new List<ResourceProfile>();
+            return allResources;
+            //List<ResourceProfile> returnList = new List<ResourceProfile>();
 
-            foreach (UnityEngine.Object listItem in resourceList.Values) {
-                returnList.Add(listItem as ResourceProfile);
-            }
-            return returnList;
+            //foreach (UnityEngine.Object listItem in resourceList.Values) {
+                //returnList.Add(listItem as ResourceProfile);
+            //}
+            //return returnList;
         }
 
     }

--- a/Assets/AnyRPG/Engine/Core/System/Scripts/Editor/ResourceSelector/ResourceSelector.cs
+++ b/Assets/AnyRPG/Engine/Core/System/Scripts/Editor/ResourceSelector/ResourceSelector.cs
@@ -192,7 +192,7 @@ public class ResourceSelector : EditorWindow
             Label l = e as Label;
             l.text = listElements[i].ResourceName;
             // I would love to put the path in a tooltip but there is currently no way to get it from Resources
-            //l.tooltip = "Path: " + AssetDatabase.GetAssetPath(listElements[i]);
+            l.tooltip = "Type: " + listElements[i].GetType().Name;
         };
 
         // Provide the list view with an explict height for every row


### PR DESCRIPTION
Stop the resource selector from displaying everything in Resources and below which disregards special folders for other games that may lay around.
The dummy resource selector does not even need the dictionary as it handles temporary (flat) lists of specific or all resources without the need to address them by name and type.